### PR TITLE
fix: 모달 헤더 레이아웃 정렬 오류 수정

### DIFF
--- a/src/components/common/Modal.stories.tsx
+++ b/src/components/common/Modal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Modal } from './Modal';
 import { Button } from './Button';
+import { useState } from 'react';
 
 const meta = {
     title: 'Components/Modal',
@@ -9,6 +10,24 @@ const meta = {
         layout: 'centered',
     },
     tags: ['autodocs'],
+    decorators: [
+        (Story, context) => {
+            const [isOpen, setIsOpen] = useState(false);
+            return (
+                <div>
+                    <Button onClick={() => setIsOpen(true)}>Open Modal</Button>
+                    <Story
+                        {...context}
+                        args={{
+                            ...context.args,
+                            isOpen,
+                            onClose: () => setIsOpen(false)
+                        }}
+                    />
+                </div>
+            );
+        }
+    ]
 } satisfies Meta<typeof Modal>;
 
 export default meta;
@@ -16,8 +35,6 @@ type Story = StoryObj<typeof Modal>;
 
 export const Default: Story = {
     args: {
-        isOpen: true,
-        onClose: () => {},
         title: 'Example Modal',
         description: 'This is a description of the modal content.',
         children: (
@@ -34,8 +51,6 @@ export const Default: Story = {
 
 export const WithoutDescription: Story = {
     args: {
-        isOpen: true,
-        onClose: () => {},
         title: 'Simple Modal',
         children: (
             <div className="space-y-4">
@@ -50,8 +65,6 @@ export const WithoutDescription: Story = {
 
 export const LongContent: Story = {
     args: {
-        isOpen: true,
-        onClose: () => {},
         title: 'Scrollable Modal',
         children: (
             <div className="space-y-4">

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -50,27 +50,29 @@ export function Modal({
                                 'w-full max-w-lg rounded-lg bg-white p-6 shadow-xl',
                                 className
                             )}>
-                                <div className="flex items-start justify-between text-gray-600">
-                                    <div className="space-y-1">
-                                        {title && (
-                                            <Dialog.Title className="text-lg font-medium">
-                                                {title}
-                                            </Dialog.Title>
-                                        )}
-                                        {description && (
-                                            <Dialog.Description className="text-sm text-gray-500">
-                                                {description}
-                                            </Dialog.Description>
-                                        )}
-                                    </div>
+                                <div className="relative mb-4">
                                     <button
                                         onClick={onClose}
-                                        className="rounded-full p-1.5 hover:bg-gray-100"
+                                        className="absolute -right-2 -top-2 rounded-full p-1.5 hover:bg-gray-100"
                                     >
-                                        <X className="h-4 w-4" />
+                                        <X className="h-4 w-4 text-gray-600" />
                                     </button>
+                                    {(title || description) && (
+                                        <div className="w-full text-gray-600">
+                                            {title && (
+                                                <Dialog.Title className="text-lg font-medium leading-6">
+                                                    {title}
+                                                </Dialog.Title>
+                                            )}
+                                            {description && (
+                                                <Dialog.Description className="mt-1 text-sm text-gray-500">
+                                                    {description}
+                                                </Dialog.Description>
+                                            )}
+                                        </div>
+                                    )}
                                 </div>
-                                <div className="mt-4">
+                                <div className="w-full">
                                     {children}
                                 </div>
                             </Dialog.Panel>


### PR DESCRIPTION
### PR 타입
- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Design
- [ ] Other

### 반영 브랜치
`fix/modal` -> `develop`

### 변경 사항
1. `Modal` 헤더 레이아웃 정렬 오류 수정
  - 제목과 설명 영역이 한쪽으로 치우치는 현상 개선
  - 전체 너비를 균일하게 사용하도록 레이아웃 구조 수정

2. Storybook 스토리 수정
  - `Modal` 스토리에 상태 관리 로직 추가 
  - 각 스토리에서 모달을 열고 닫을 수 있도록 수정
  - docs 페이지에서 모달이 겹치는 문제 해결

### 관련 이슈
- Closes #1 
- Realates to #2 
