### PR TITLE
feat: 사용자 정보 관리 로직 구현

### DIFF
--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -1,0 +1,48 @@
+import {ApiResponse, User} from "@/types/auth";
+import {useAuthStore} from "@/store/auth";
+
+export const userApi = {
+    // 현재 사용자 정보 조회
+    getMe: async (): Promise<ApiResponse<User>> => {
+        const { accessToken } = useAuthStore.getState();
+        const response = await fetch('/api/users/me', {
+            headers: {
+                'Authorization': `Bearer ${accessToken}`
+            }
+        });
+
+        if (!response.ok) throw new Error('Failed to fetch user data');
+        return response.json();
+    },
+
+    // 사용자 프로필 업데이트
+    updateProfile: async (data: Partial<User>): Promise<ApiResponse<User>> => {
+        const { accessToken } = useAuthStore.getState();
+        const response = await fetch('/api/users/me', {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${accessToken}`
+            },
+            body: JSON.stringify(data)
+        });
+
+        if (!response.ok) throw new Error('Failed to update profile');
+        return response.json();
+    },
+
+    // 프로필 이미지 업로드
+    uploadProfileImage: async (formData: FormData): Promise<ApiResponse<{imageUrl: string}>> => {
+        const { accessToken } = useAuthStore.getState();
+        const response = await fetch('/api/users/me/image', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`
+            },
+            body: formData
+        });
+
+        if (!response.ok) throw new Error('Failed to upload image');
+        return response.json();
+    }
+}

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -8,15 +8,14 @@ export function decodeToken(token: string | null): JwtPayload | null {
         const payload = Buffer.from(base64Payload, 'base64').toString('ascii');
         const decoded = JSON.parse(payload) as JwtPayload;
 
-        if (decoded.role && !['user', 'mentor', 'admin'].includes(decoded.role)) {
+        if (!decoded.sub || !decoded.exp) {
             return null;
         }
 
-        if (!decoded.sub || !decoded.email || !decoded.exp) {
-            return null;
-        }
-
-        return decoded as JwtPayload;
+        return {
+            sub: decoded.sub,
+            exp: decoded.exp
+        };
     } catch {
         return null;
     }

--- a/src/lib/hooks/useLogin.ts
+++ b/src/lib/hooks/useLogin.ts
@@ -6,10 +6,12 @@ import {authApi} from "@/lib/api/auth";
 import {useAuthStore} from "@/store/auth";
 import {LoginForm} from "@/types/auth";
 import {validateEmail} from "@/lib/auth/validators";
+import {useUserStore} from "@/store/user";
 
 export function useLogin() {
     const router = useRouter();
     const { signIn } = useAuthStore();
+    const { fetchUser } = useUserStore();
     const [form, setForm] = useState<LoginForm>({
         email: '',
         password: ''
@@ -60,8 +62,12 @@ export function useLogin() {
         setIsLoading(true);
         try {
             const response = await authApi.signIn(form);
-            signIn(response.data);
-            router.push('/');
+
+            if (response.success) {
+                signIn(response.data);
+                await fetchUser();
+                router.push('/');
+            }
         } catch {
             setErrors({ password: '로그인에 실패했습니다.' });
         } finally {

--- a/src/lib/hooks/useSignup.ts
+++ b/src/lib/hooks/useSignup.ts
@@ -4,6 +4,7 @@ import {useRouter, useSearchParams} from "next/navigation";
 import {useEffect, useState} from "react";
 import {authApi} from "@/lib/api/auth";
 import {useAuthStore} from "@/store/auth";
+import {useUserStore} from "@/store/user";
 import {PasswordValidation, SignupForm, VerificationState} from "@/types/auth";
 import {doPasswordsMatch, isPasswordValid, validatePassword} from "@/lib/auth/validators";
 
@@ -11,6 +12,7 @@ export function useSignup() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const { signIn } = useAuthStore();
+    const { fetchUser } = useUserStore();
 
     const [form, setForm] = useState<SignupForm>({
         email: '',
@@ -151,10 +153,8 @@ export function useSignup() {
             });
 
             if (response.success) {
-                signIn({
-                    accessToken: response.data.accessToken,
-                    refreshToken: response.data.refreshToken
-                });
+                signIn(response.data);
+                await fetchUser();
                 router.push('/register');
             }
         } catch {

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -6,43 +6,36 @@ import {decodeToken} from "@/lib/auth/jwt";
 export const useAuthStore = create<AuthState>()(
     persist(
         (set) => ({
-            user: null,
             accessToken: null,
             refreshToken: null,
             isAuthenticated: false,
+            userId: null,
+            email: null,
 
-            setTokens: (accessToken: string, refreshToken: string) => {
+            setTokens: (accessToken, refreshToken) => {
                 const decoded = decodeToken(accessToken);
-                if (!decoded) {
+                if (!decoded?.sub) {
                     console.error('Failed to decode JWT token');
                     return;
                 }
 
                 set({
-                    user: {
-                        id: decoded.sub,
-                        email: decoded.email,
-                        role: decoded.role
-                    },
+                    userId: decoded.sub,
                     accessToken,
                     refreshToken,
                     isAuthenticated: true
                 })
             },
 
-            signIn: (tokens: { accessToken: string, refreshToken: string }) => {
+            signIn: (tokens) => {
                 const decoded = decodeToken(tokens.accessToken);
-                if (!decoded) {
+                if (!decoded?.sub) {
                     console.error('Failed to decode JWT token');
                     return;
                 }
 
                 set({
-                    user: {
-                        id: decoded.sub,
-                        email: decoded.email,
-                        role: decoded.role
-                    },
+                    userId: decoded.sub,
                     accessToken: tokens.accessToken,
                     refreshToken: tokens.refreshToken,
                     isAuthenticated: true,
@@ -51,6 +44,7 @@ export const useAuthStore = create<AuthState>()(
 
             signOut: () =>
                 set({
+                    userId: null,
                     accessToken: null,
                     refreshToken: null,
                     isAuthenticated: false
@@ -60,7 +54,7 @@ export const useAuthStore = create<AuthState>()(
             name: 'auth_storage',
             storage: createJSONStorage(() => localStorage),
             partialize: (state) => ({
-                user: state.user,
+                userId: state.userId,
                 accessToken: state.accessToken,
                 refreshToken: state.refreshToken,
                 isAuthenticated: state.isAuthenticated

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,0 +1,63 @@
+import {UserState} from "@/types/auth";
+import {create} from "zustand";
+import {userApi} from "@/lib/api/user";
+
+export const useUserStore = create<UserState>((set) => ({
+    user: null,
+    isLoading: false,
+    error: null,
+
+    fetchUser: async () => {
+        try {
+            set({ isLoading: true, error: null });
+            const response = await userApi.getMe();
+
+            if (response.success) {
+                set({ user: response.data, isLoading: false });
+            }
+        } catch (error) {
+            set({ error: (error as Error).message, isLoading: false });
+        }
+    },
+
+    updateProfile: async (data) => {
+        try {
+            set({ isLoading: true, error: null });
+            const response = await userApi.updateProfile(data);
+
+            if (response.success) {
+                set({
+                    user: response.data,
+                    isLoading: false
+                });
+            }
+        } catch (error) {
+            set({ error: (error as Error).message, isLoading: false });
+        }
+    },
+
+    uploadProfileImage: async (file) => {
+        try {
+            set({ isLoading: true, error: null });
+            const formData = new FormData();
+            formData.append('image', file);
+
+            const response = await userApi.uploadProfileImage(formData);
+
+            if (response.success) {
+                set(state => ({
+                    user: state.user ? {
+                        ...state.user,
+                        profileImage: response.data.imageUrl
+                    } : null,
+                    isLoading: false
+                }));
+            }
+        } catch (error) {
+            set({ error: (error as Error).message, isLoading: false });
+        }
+    },
+
+    setUser: (user) => set({ user }),
+    reset: () => set({ user: null, error: null, isLoading: false })
+}));

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -10,18 +10,32 @@ export interface User extends AuthResponseUser {
     name?: string;
     role?: UserRole;
     profileImage?: string;
+    isProfileComplete?: boolean;
 }
 
 /** 상태 타입 */
 export interface AuthState {
-    user: User | null;
     accessToken: string | null;
     refreshToken: string | null;
     isAuthenticated: boolean;
+    userId: string | null;
+    email: string | null;
 
     setTokens: (accessToken: string, refreshToken: string) => void;
-    signIn: (tokens: { accessToken: string, refreshToken: string }) => void;
+    signIn: (tokens: AuthResponse) => void;
     signOut: () => void;
+}
+
+export interface UserState {
+    user: User | null;
+    isLoading: boolean;
+    error: string | null;
+
+    fetchUser: () => Promise<void>;
+    updateProfile: (data: Partial<User>) => Promise<void>;
+    uploadProfileImage: (file: File) => Promise<void>;
+    setUser: (user: User | null) => void;
+    reset: () => void;
 }
 
 export interface VerificationState {
@@ -77,7 +91,5 @@ export interface WithAuthProps {
 /** JWT Payload 타입 */
 export interface JwtPayload {
     sub: string;
-    email: string;
-    role?: UserRole;
     exp: number;
 }


### PR DESCRIPTION
### PR 타입
- [x] Feature
- [ ] BugFix
- [ ] Refactor
- [ ] Design
- [ ] Other

### 반영 브랜치
`feature/user` -> `develop`

### 변경 사항
#### JWT 관련
- `JwtPayload` 타입을 `userId(sub)`와 `exp`만 포함하도록 수정
- `decodeToken` 함수 로직 단순화

#### Store 구현 및 수정
- `UserStore` 구현 (사용자 정보 상태 관리)
  - 사용자 정보 조회/수정 기능
  - 로딩/에러 상태 관리
- `AuthStore` 단순화
  - `user` 정보 제거
  - JWT에서 `userId`만 디코딩하여 저장

#### User 관련 API 구현
- `getMe`: 현재 사용자 정보 조회
- `updateProfile`: 사용자 프로필 업데이트
- `uploadProfileImage`: 프로필 이미지 업로드

### 관련 이슈
- Closes #6 
